### PR TITLE
update go-haiku

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/u16-io/FindSenryu4Discord
 go 1.26.1
 
 require (
-	github.com/0x307e/go-haiku v0.0.0-20260328142204-ab9a920132b1
+	github.com/0x307e/go-haiku v0.0.0-20260329080508-9d9784186eac
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/cockroachdb/errors v1.11.3
 	github.com/ikawaha/kagome-dict/uni v1.1.9

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/0x307e/go-haiku v0.0.0-20260328142204-ab9a920132b1 h1:EPZy5Sfqm7teo5BQuwect2YpxdjSB28REBFsByO2RuU=
-github.com/0x307e/go-haiku v0.0.0-20260328142204-ab9a920132b1/go.mod h1:AFxkLUJbj5HTSMCksfgb4V7LFxY3dTlDKdCjWoToyCI=
+github.com/0x307e/go-haiku v0.0.0-20260329080508-9d9784186eac h1:3Dvxa46Dd2pF0lYQ0KinttnM5EY5zagaYm57TBNgxpk=
+github.com/0x307e/go-haiku v0.0.0-20260329080508-9d9784186eac/go.mod h1:AFxkLUJbj5HTSMCksfgb4V7LFxY3dTlDKdCjWoToyCI=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
## Summary
- go-haiku依存を最新版に更新 (`20260328142204` → `20260329080508`)

## Test plan
- [x] `go build ./...` でビルド確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)