### PR TITLE
feat: 川柳検出の誤検出防止フィルタを追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !**/*.go
+!**/*.sql
 !go.mod
 !go.sum
 !config.toml

--- a/config/config.go
+++ b/config/config.go
@@ -49,11 +49,11 @@ type LogConfig struct {
 
 // AdminConfig holds admin-related configuration
 type AdminConfig struct {
-	OwnerIDs          []string `koanf:"owner_ids"`          // Bot admin Discord IDs
-	GuildID           string   `koanf:"guild_id"`           // Guild ID for admin commands
-	LogChannelID      string   `koanf:"log_channel_id"`     // Real-time notification channel (guild join/leave)
-	ReportChannelID   string   `koanf:"report_channel_id"`  // Daily report channel
-	ContactChannelID  string   `koanf:"contact_channel_id"` // Contact notification channel (future use)
+	OwnerIDs         []string `koanf:"owner_ids"`          // Bot admin Discord IDs
+	GuildID          string   `koanf:"guild_id"`           // Guild ID for admin commands
+	LogChannelID     string   `koanf:"log_channel_id"`     // Real-time notification channel (guild join/leave)
+	ReportChannelID  string   `koanf:"report_channel_id"`  // Daily report channel
+	ContactChannelID string   `koanf:"contact_channel_id"` // Contact notification channel (future use)
 }
 
 // ServerConfig holds HTTP server configuration

--- a/main.go
+++ b/main.go
@@ -776,6 +776,17 @@ func findHaikuSafe(content string, rule []int) (result []string) {
 	return haiku.Find(content, rule)
 }
 
+var (
+	reFencedCodeBlock = regexp.MustCompile("(?s)```.*?```")
+	reInlineCode      = regexp.MustCompile("`[^`]+`")
+)
+
+func stripCodeBlocks(s string) string {
+	s = reFencedCodeBlock.ReplaceAllString(s, "")
+	s = reInlineCode.ReplaceAllString(s, "")
+	return s
+}
+
 var reSpoiler = regexp.MustCompile(`\|\|.+?\|\|`)
 
 func containsSpoiler(s string) bool {

--- a/main.go
+++ b/main.go
@@ -810,6 +810,11 @@ func haikuSpansNewline(content, haikuResult string) bool {
 	return !strings.Contains(content, matched)
 }
 
+// japaneseCharRatioThreshold is the minimum ratio of Japanese characters
+// (Hiragana, Katakana, Han) to total non-space characters required for a
+// message to be considered "Japanese-rich" and eligible for senryu detection.
+const japaneseCharRatioThreshold = 0.5
+
 func isJapaneseRich(s string) bool {
 	var total, jp int
 	for _, r := range s {
@@ -817,14 +822,16 @@ func isJapaneseRich(s string) bool {
 			continue
 		}
 		total++
-		if unicode.In(r, unicode.Hiragana, unicode.Katakana, unicode.Han) {
+		if unicode.In(r, unicode.Hiragana, unicode.Katakana, unicode.Han) ||
+			r == 'ー' || // Katakana long vowel mark (U+30FC)
+			r == '・' { // Katakana middle dot (U+30FB)
 			jp++
 		}
 	}
 	if total == 0 {
 		return false
 	}
-	return float64(jp)/float64(total) >= 0.5
+	return float64(jp)/float64(total) >= japaneseCharRatioThreshold
 }
 
 // isBotPermissionError returns true if the error is a Discord API error

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"unicode"
 
 	"github.com/cockroachdb/errors"
 	"github.com/u16-io/FindSenryu4Discord/commands"
@@ -795,6 +796,23 @@ func containsSpoiler(s string) bool {
 
 func stripSpoilerMarkers(s string) string {
 	return strings.ReplaceAll(s, "||", "")
+}
+
+func isJapaneseRich(s string) bool {
+	var total, jp int
+	for _, r := range s {
+		if unicode.IsSpace(r) {
+			continue
+		}
+		total++
+		if unicode.In(r, unicode.Hiragana, unicode.Katakana, unicode.Han) {
+			jp++
+		}
+	}
+	if total == 0 {
+		return false
+	}
+	return float64(jp)/float64(total) >= 0.5
 }
 
 // isBotPermissionError returns true if the error is a Discord API error

--- a/main.go
+++ b/main.go
@@ -523,8 +523,12 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			if spoiler {
 				content = stripSpoilerMarkers(content)
 			}
+			content = stripCodeBlocks(content)
+			if !isJapaneseRich(content) {
+				return
+			}
 			h := findHaikuSafe(content, []int{5, 7, 5})
-			if len(h) != 0 {
+			if len(h) != 0 && !strings.Contains(h[0], "\n") {
 				senryu := strings.Split(h[0], " ")
 				created, err := service.CreateSenryu(
 					model.Senryu{

--- a/main.go
+++ b/main.go
@@ -528,7 +528,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 				return
 			}
 			h := findHaikuSafe(content, []int{5, 7, 5})
-			if len(h) != 0 && !strings.Contains(h[0], "\n") {
+			if len(h) != 0 && !haikuSpansNewline(content, h[0]) {
 				senryu := strings.Split(h[0], " ")
 				created, err := service.CreateSenryu(
 					model.Senryu{
@@ -800,6 +800,14 @@ func containsSpoiler(s string) bool {
 
 func stripSpoilerMarkers(s string) string {
 	return strings.ReplaceAll(s, "||", "")
+}
+
+func haikuSpansNewline(content, haikuResult string) bool {
+	if !strings.Contains(content, "\n") {
+		return false
+	}
+	matched := strings.ReplaceAll(haikuResult, " ", "")
+	return !strings.Contains(content, matched)
 }
 
 func isJapaneseRich(s string) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -143,6 +143,36 @@ func TestStripSpoilerMarkers(t *testing.T) {
 	}
 }
 
+func TestStripCodeBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"フェンスドコードブロック除去", "前文```go\nfmt.Println()\n```後文", "前文後文"},
+		{"インラインコード除去", "変数`x`を使う", "変数を使う"},
+		{"フェンスドとインライン混在", "```code```と`inline`", "と"},
+		{"コードブロックなし", "古池や蛙飛び込む水の音", "古池や蛙飛び込む水の音"},
+		{"空文字列", "", ""},
+		{"複数フェンスドコードブロック", "あ```a```い```b```う", "あいう"},
+		{"複数インラインコード", "`a`と`b`と`c`", "とと"},
+		{"改行を含むフェンスド", "前\n```\nline1\nline2\n```\n後", "前\n\n後"},
+		{"閉じられていないフェンスド", "```未閉じコード", "```未閉じコード"},
+		{"閉じられていないインライン", "`未閉じインライン", "`未閉じインライン"},
+		{"空のインラインコード", "空``です", "空``です"},
+		{"言語指定付きフェンスド", "```python\nprint('hello')\n```", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripCodeBlocks(tt.input)
+			if got != tt.want {
+				t.Errorf("stripCodeBlocks(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsParentChannelMuted_親チャンネルがミュート(t *testing.T) {
 	setupTestDB(t)
 

--- a/main_test.go
+++ b/main_test.go
@@ -173,6 +173,37 @@ func TestStripCodeBlocks(t *testing.T) {
 	}
 }
 
+func TestIsJapaneseRich(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"全てひらがな", "ふるいけやかわずとびこむ", true},
+		{"全てカタカナ", "フルイケヤカワズトビコム", true},
+		{"全て漢字", "古池蛙飛込水音", true},
+		{"日本語混合", "古池や蛙飛びこむ水の音", true},
+		{"全て英語", "hello world this is a test", false},
+		{"空文字列", "", false},
+		{"スペースのみ", "   ", false},
+		{"日本語50%ちょうど", "あa", true},
+		{"日本語50%未満", "あab", false},
+		{"日本語とスペース混合", "古池や 蛙飛びこむ 水の音", true},
+		{"コードっぽい文字列", "fmt.Println(hello)", false},
+		{"全角英数字は日本語でない", "ＡＢＣＤ", false},
+		{"日本語と記号混合", "古池や！蛙飛びこむ？水の音", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isJapaneseRich(tt.input)
+			if got != tt.want {
+				t.Errorf("isJapaneseRich(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsParentChannelMuted_親チャンネルがミュート(t *testing.T) {
 	setupTestDB(t)
 

--- a/main_test.go
+++ b/main_test.go
@@ -192,6 +192,9 @@ func TestIsJapaneseRich(t *testing.T) {
 		{"コードっぽい文字列", "fmt.Println(hello)", false},
 		{"全角英数字は日本語でない", "ＡＢＣＤ", false},
 		{"日本語と記号混合", "古池や！蛙飛びこむ？水の音", true},
+		{"カタカナ長音符を含む", "コーヒー", true},
+		{"長音符のみ", "ーーーー", true},
+		{"中黒を含むカタカナ", "ワールド・カップ", true},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -204,6 +204,82 @@ func TestIsJapaneseRich(t *testing.T) {
 	}
 }
 
+func TestHaikuSpansNewline(t *testing.T) {
+	tests := []struct {
+		name        string
+		content     string
+		haikuResult string
+		want        bool
+	}{
+		{"改行なし", "古池や蛙飛びこむ水の音", "古池や 蛙飛びこむ 水の音", false},
+		{"改行あり結果がまたぐ", "古池や蛙飛びこむ\n水の音", "古池や 蛙飛びこむ 水の音", true},
+		{"3行書き", "古池や\n蛙飛びこむ\n水の音", "古池や 蛙飛びこむ 水の音", true},
+		{"改行後に完全な俳句", "こんにちは\n古池や蛙飛びこむ水の音", "古池や 蛙飛びこむ 水の音", false},
+		{"俳句後に改行", "古池や蛙飛びこむ水の音\nさようなら", "古池や 蛙飛びこむ 水の音", false},
+		{"空文字列", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := haikuSpansNewline(tt.content, tt.haikuResult)
+			if got != tt.want {
+				t.Errorf("haikuSpansNewline(%q, %q) = %v, want %v", tt.content, tt.haikuResult, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectionFiltering_統合テスト(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    string
+		wantFilter bool // true = should be filtered out (not detected as senryu)
+		reason     string
+	}{
+		{
+			"コードブロック内の日本語",
+			"```\n古池や蛙飛びこむ水の音\n```",
+			true,
+			"コードブロック除去後に日本語が残らない",
+		},
+		{
+			"インラインコード内の日本語",
+			"`古池や蛙飛びこむ水の音`",
+			true,
+			"インラインコード除去後に日本語が残らない",
+		},
+		{
+			"英語のみのテキスト",
+			"the quick brown fox jumps over lazy dog",
+			true,
+			"日本語比率が低い",
+		},
+		{
+			"コードっぽいテキスト",
+			"func main() { fmt.Println(hello) }",
+			true,
+			"日本語比率が低い",
+		},
+		{
+			"コードブロック外の日本語テキスト",
+			"```go\nfmt.Println()\n```\n普通の日本語テキスト",
+			false,
+			"コードブロック除去後に日本語が残る",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := stripCodeBlocks(tt.content)
+			filtered := !isJapaneseRich(content)
+			if filtered != tt.wantFilter {
+				t.Errorf("content=%q -> stripCodeBlocks=%q -> isJapaneseRich=%v, wantFilter=%v (%s)",
+					tt.content, content, !filtered, tt.wantFilter, tt.reason)
+			}
+		})
+	}
+}
+
 func TestIsParentChannelMuted_親チャンネルがミュート(t *testing.T) {
 	setupTestDB(t)
 


### PR DESCRIPTION
## Summary
- コードブロック（フェンスド/インライン）内のテキストを検出対象から除外
- 日本語文字比率が低いテキスト（コード等）をスキップ
- 改行をまたぐ誤検出を防止（`haikuSpansNewline` による後判定）
- カタカナ長音符 `ー` / 中黒 `・` を日本語文字としてカウント

Closes #88

## Test plan
- [x] `stripCodeBlocks` テスト（12ケース）
- [x] `isJapaneseRich` テスト（16ケース、長音符含む）
- [x] `haikuSpansNewline` テスト（6ケース）
- [x] 統合テスト（コードブロック、非日本語、改行）
- [x] 既存検出動作のリグレッション確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)