### PR TITLE
feat: 「詠むな」コマンドのメンションを表示名に変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -672,13 +672,7 @@ func handleRankCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		if err != nil {
 			continue
 		}
-		displayName := member.Nick
-		if displayName == "" {
-			displayName = member.User.GlobalName
-		}
-		if displayName == "" {
-			displayName = member.User.Username
-		}
+		displayName := resolveDisplayName(member)
 		embed.Fields = append(embed.Fields, &discordgo.MessageEmbedField{
 			Name:   fmt.Sprintf("%s 第%d位: %d回", medals[rank.Rank-1], rank.Rank, rank.Count),
 			Value:  displayName,
@@ -736,13 +730,7 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 				if err != nil {
 					authorName = "<@" + senryu.AuthorID + ">"
 				} else {
-					authorName = member.Nick
-					if authorName == "" {
-						authorName = member.User.GlobalName
-					}
-					if authorName == "" {
-						authorName = member.User.Username
-					}
+					authorName = resolveDisplayName(member)
 				}
 			}
 			var reply string
@@ -762,6 +750,18 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 		return true
 	}
 	return false
+}
+
+// resolveDisplayName returns the best display name for a guild member,
+// preferring Nick > GlobalName > Username.
+func resolveDisplayName(member *discordgo.Member) string {
+	if member.Nick != "" {
+		return member.Nick
+	}
+	if member.User.GlobalName != "" {
+		return member.User.GlobalName
+	}
+	return member.User.Username
 }
 
 // isParentChannelMuted checks if the parent channel of a thread is muted.
@@ -884,11 +884,7 @@ func getWriters(senryus []model.Senryu, guildID string, session *discordgo.Sessi
 		if err != nil {
 			continue
 		}
-		if member.Nick != "" {
-			writers = append(writers, member.Nick)
-		} else {
-			writers = append(writers, member.User.Username)
-		}
+		writers = append(writers, resolveDisplayName(member))
 	}
 	return sliceUnique(writers)
 }

--- a/main.go
+++ b/main.go
@@ -719,7 +719,7 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 		}
 		return true
 	case "詠むな":
-		senryu, err := service.GetLastSenryu(m.GuildID, m.Author.ID)
+		senryu, err := service.GetLastSenryu(m.GuildID)
 		if err != nil {
 			if errors.Is(err, service.ErrSenryuNotFound) {
 				s.ChannelMessageSendReply(m.ChannelID, "まだ誰も詠んでいません。", m.Reference())
@@ -728,9 +728,32 @@ func handleYomeYomuna(m *discordgo.MessageCreate, s *discordgo.Session) bool {
 				s.MessageReactionAdd(m.ChannelID, m.ID, "❌")
 			}
 		} else {
+			var authorName string
+			if senryu.AuthorID == m.Author.ID {
+				authorName = "お前"
+			} else {
+				member, err := s.GuildMember(m.GuildID, senryu.AuthorID)
+				if err != nil {
+					authorName = "<@" + senryu.AuthorID + ">"
+				} else {
+					authorName = member.Nick
+					if authorName == "" {
+						authorName = member.User.GlobalName
+					}
+					if authorName == "" {
+						authorName = member.User.Username
+					}
+				}
+			}
+			var reply string
+			if senryu.Spoiler != nil && *senryu.Spoiler {
+				reply = authorName + "が||「" + senryu.Kamigo + " " + senryu.Nakasichi + " " + senryu.Simogo + "」||って詠んだのが最後やぞ"
+			} else {
+				reply = authorName + "が「" + senryu.Kamigo + " " + senryu.Nakasichi + " " + senryu.Simogo + "」って詠んだのが最後やぞ"
+			}
 			if _, err := s.ChannelMessageSendReply(
 				m.ChannelID,
-				senryu,
+				reply,
 				m.Reference(),
 			); err != nil {
 				logger.Warn("Failed to send reply", "error", err, "channel_id", m.ChannelID)

--- a/service/senryu.go
+++ b/service/senryu.go
@@ -101,40 +101,28 @@ func CreateSenryu(s model.Senryu) (model.Senryu, error) {
 }
 
 // GetLastSenryu returns the last senryu in a server
-func GetLastSenryu(serverID string, userID string) (string, error) {
+func GetLastSenryu(serverID string) (*model.Senryu, error) {
 	metrics.RecordDatabaseOperation("get_last_senryu")
 
 	s := model.Senryu{}
 	if err := db.DB.Where(&model.Senryu{ServerID: serverID}).Last(&s).Error; err != nil {
 		if gorm.IsRecordNotFoundError(err) {
-			return "", ErrSenryuNotFound
+			return nil, ErrSenryuNotFound
 		}
 		metrics.RecordError("database")
 		logger.Warn("Failed to get last senryu",
 			"error", err,
 			"server_id", serverID,
 		)
-		return "", errors.Wrap(err, "failed to get last senryu")
+		return nil, errors.Wrap(err, "failed to get last senryu")
 	}
 
 	if err := decryptSenryuFields(&s); err != nil {
 		logger.Error("Failed to decrypt senryu", "error", err, "id", s.ID)
-		return "", err
+		return nil, err
 	}
 
-	var str string
-	if userID == s.AuthorID {
-		str = "お前"
-	} else {
-		str = "<@" + s.AuthorID + "> "
-	}
-	if s.Spoiler != nil && *s.Spoiler {
-		str += "が||「" + s.Kamigo + " " + s.Nakasichi + " " + s.Simogo + "」||って詠んだのが最後やぞ"
-	} else {
-		str += "が「" + s.Kamigo + " " + s.Nakasichi + " " + s.Simogo + "」って詠んだのが最後やぞ"
-	}
-
-	return str, nil
+	return &s, nil
 }
 
 // GetThreeRandomSenryus returns three random senryus for generating a new one

--- a/service/senryu_test.go
+++ b/service/senryu_test.go
@@ -644,6 +644,9 @@ func TestCountSenryusByAuthor_別ユーザーは含まない(t *testing.T) {
 
 func TestGetLastSenryu_最後の川柳を返す(t *testing.T) {
 	setupSenryuTestDB(t)
+	if err := crypto.Init(""); err != nil {
+		t.Fatalf("crypto init failed: %v", err)
+	}
 
 	db.DB.Create(&model.Senryu{
 		ServerID: "guild1", AuthorID: "user1",
@@ -676,6 +679,9 @@ func TestGetLastSenryu_最後の川柳を返す(t *testing.T) {
 
 func TestGetLastSenryu_川柳が存在しない場合(t *testing.T) {
 	setupSenryuTestDB(t)
+	if err := crypto.Init(""); err != nil {
+		t.Fatalf("crypto init failed: %v", err)
+	}
 
 	_, err := GetLastSenryu("guild1")
 	if err == nil {
@@ -688,6 +694,9 @@ func TestGetLastSenryu_川柳が存在しない場合(t *testing.T) {
 
 func TestGetLastSenryu_サーバーごとに独立(t *testing.T) {
 	setupSenryuTestDB(t)
+	if err := crypto.Init(""); err != nil {
+		t.Fatalf("crypto init failed: %v", err)
+	}
 
 	db.DB.Create(&model.Senryu{
 		ServerID: "guild1", AuthorID: "user1",
@@ -714,6 +723,9 @@ func TestGetLastSenryu_サーバーごとに独立(t *testing.T) {
 
 func TestGetLastSenryu_スポイラー付き川柳(t *testing.T) {
 	setupSenryuTestDB(t)
+	if err := crypto.Init(""); err != nil {
+		t.Fatalf("crypto init failed: %v", err)
+	}
 
 	db.DB.Create(&model.Senryu{
 		ServerID: "guild1", AuthorID: "user1",
@@ -732,6 +744,9 @@ func TestGetLastSenryu_スポイラー付き川柳(t *testing.T) {
 
 func TestGetLastSenryu_スポイラーなし川柳(t *testing.T) {
 	setupSenryuTestDB(t)
+	if err := crypto.Init(""); err != nil {
+		t.Fatalf("crypto init failed: %v", err)
+	}
 
 	db.DB.Create(&model.Senryu{
 		ServerID: "guild1", AuthorID: "user1",

--- a/service/senryu_test.go
+++ b/service/senryu_test.go
@@ -1,9 +1,9 @@
 package service
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/cockroachdb/errors"
 	"github.com/jinzhu/gorm"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/u16-io/FindSenryu4Discord/db"
@@ -24,6 +24,10 @@ func setupSenryuTestDB(t *testing.T) {
 	t.Cleanup(func() {
 		db.DB.Close()
 	})
+}
+
+func boolPtr(b bool) *bool {
+	return &b
 }
 
 func TestCreateSenryu_暗号化有効時にDBに平文が保存されない(t *testing.T) {
@@ -130,7 +134,7 @@ func TestGetSenryuByID_暗号化有効時に平文が復元される(t *testing.
 	}
 }
 
-func TestGetLastSenryu_暗号化有効時に復号された文字列を返す(t *testing.T) {
+func TestGetLastSenryu_暗号化有効時に復号されたデータを返す(t *testing.T) {
 	setupSenryuTestDB(t)
 	if err := crypto.Init(testEncryptionKey); err != nil {
 		t.Fatalf("crypto init failed: %v", err)
@@ -149,19 +153,19 @@ func TestGetLastSenryu_暗号化有効時に復号された文字列を返す(t 
 		t.Fatalf("CreateSenryu failed: %v", err)
 	}
 
-	result, err := GetLastSenryu("server1", "author1")
+	got, err := GetLastSenryu("server1")
 	if err != nil {
 		t.Fatalf("GetLastSenryu failed: %v", err)
 	}
 
-	if !strings.Contains(result, "春すぎて") {
-		t.Errorf("result should contain decrypted Kamigo, got: %s", result)
+	if got.Kamigo != "春すぎて" {
+		t.Errorf("Kamigo: expected %q, got %q", "春すぎて", got.Kamigo)
 	}
-	if !strings.Contains(result, "夏来にけらし") {
-		t.Errorf("result should contain decrypted Nakasichi, got: %s", result)
+	if got.Nakasichi != "夏来にけらし" {
+		t.Errorf("Nakasichi: expected %q, got %q", "夏来にけらし", got.Nakasichi)
 	}
-	if !strings.Contains(result, "白妙の") {
-		t.Errorf("result should contain decrypted Simogo, got: %s", result)
+	if got.Simogo != "白妙の" {
+		t.Errorf("Simogo: expected %q, got %q", "白妙の", got.Simogo)
 	}
 }
 
@@ -635,5 +639,111 @@ func TestCountSenryusByAuthor_別ユーザーは含まない(t *testing.T) {
 	}
 	if count != 5 {
 		t.Errorf("expected 5, got %d", count)
+	}
+}
+
+func TestGetLastSenryu_最後の川柳を返す(t *testing.T) {
+	setupSenryuTestDB(t)
+
+	db.DB.Create(&model.Senryu{
+		ServerID: "guild1", AuthorID: "user1",
+		Kamigo: "古池や", Nakasichi: "蛙飛び込む", Simogo: "水の音",
+		Spoiler: boolPtr(false),
+	})
+	db.DB.Create(&model.Senryu{
+		ServerID: "guild1", AuthorID: "user2",
+		Kamigo: "柿くへば", Nakasichi: "鐘が鳴るなり", Simogo: "法隆寺",
+		Spoiler: boolPtr(false),
+	})
+
+	got, err := GetLastSenryu("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AuthorID != "user2" {
+		t.Errorf("AuthorID = %q, want %q", got.AuthorID, "user2")
+	}
+	if got.Kamigo != "柿くへば" {
+		t.Errorf("Kamigo = %q, want %q", got.Kamigo, "柿くへば")
+	}
+	if got.Nakasichi != "鐘が鳴るなり" {
+		t.Errorf("Nakasichi = %q, want %q", got.Nakasichi, "鐘が鳴るなり")
+	}
+	if got.Simogo != "法隆寺" {
+		t.Errorf("Simogo = %q, want %q", got.Simogo, "法隆寺")
+	}
+}
+
+func TestGetLastSenryu_川柳が存在しない場合(t *testing.T) {
+	setupSenryuTestDB(t)
+
+	_, err := GetLastSenryu("guild1")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrSenryuNotFound) {
+		t.Errorf("error = %v, want ErrSenryuNotFound", err)
+	}
+}
+
+func TestGetLastSenryu_サーバーごとに独立(t *testing.T) {
+	setupSenryuTestDB(t)
+
+	db.DB.Create(&model.Senryu{
+		ServerID: "guild1", AuthorID: "user1",
+		Kamigo: "古池や", Nakasichi: "蛙飛び込む", Simogo: "水の音",
+		Spoiler: boolPtr(false),
+	})
+	db.DB.Create(&model.Senryu{
+		ServerID: "guild2", AuthorID: "user2",
+		Kamigo: "柿くへば", Nakasichi: "鐘が鳴るなり", Simogo: "法隆寺",
+		Spoiler: boolPtr(false),
+	})
+
+	got, err := GetLastSenryu("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.AuthorID != "user1" {
+		t.Errorf("AuthorID = %q, want %q", got.AuthorID, "user1")
+	}
+	if got.ServerID != "guild1" {
+		t.Errorf("ServerID = %q, want %q", got.ServerID, "guild1")
+	}
+}
+
+func TestGetLastSenryu_スポイラー付き川柳(t *testing.T) {
+	setupSenryuTestDB(t)
+
+	db.DB.Create(&model.Senryu{
+		ServerID: "guild1", AuthorID: "user1",
+		Kamigo: "秘密の", Nakasichi: "内容が含まれる", Simogo: "川柳だ",
+		Spoiler: boolPtr(true),
+	})
+
+	got, err := GetLastSenryu("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spoiler == nil || !*got.Spoiler {
+		t.Error("Spoiler should be true")
+	}
+}
+
+func TestGetLastSenryu_スポイラーなし川柳(t *testing.T) {
+	setupSenryuTestDB(t)
+
+	db.DB.Create(&model.Senryu{
+		ServerID: "guild1", AuthorID: "user1",
+		Kamigo: "古池や", Nakasichi: "蛙飛び込む", Simogo: "水の音",
+		Spoiler: boolPtr(false),
+	})
+
+	got, err := GetLastSenryu("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spoiler == nil || *got.Spoiler {
+		t.Error("Spoiler should be false")
 	}
 }


### PR DESCRIPTION
## Summary
- `GetLastSenryu` の戻り値を `*model.Senryu` に変更し、service層から表示ロジックを分離
- 「詠むな」の詠み手表示を Discord メンション (`<@ID>`) から表示名（ニックネーム/ユーザー名）に変更
- `resolveDisplayName` 共通ヘルパーを作成し、ランキング・詠むな・getWriters の表示名解決を統一
- `GuildMember` 失敗時は `<@ID>` にフォールバック、自分の場合は「お前」を維持

Closes #89

## Test plan
- [x] `GetLastSenryu` のユニットテスト（5ケース）
- [x] 暗号化有効/無効、スポイラーあり/なし
- [x] サーバー間独立性、川柳なしのエラー
- [x] 既存テストのリグレッション確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)