### PR TITLE
feat: mute/unmuteコマンドに権限チェックを追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !**/*.go
+!**/*.sql
 !go.mod
 !go.sum
 !config.toml

--- a/commands/admin.go
+++ b/commands/admin.go
@@ -221,6 +221,13 @@ func isServerAdmin(i *discordgo.InteractionCreate) bool {
 	return i.Member.Permissions&discordgo.PermissionAdministrator != 0
 }
 
+func canManageChannel(i *discordgo.InteractionCreate) bool {
+	if i.Member == nil {
+		return false
+	}
+	return i.Member.Permissions&(discordgo.PermissionAdministrator|discordgo.PermissionManageChannels) != 0
+}
+
 func respondError(s *discordgo.Session, i *discordgo.InteractionCreate, message string) {
 	s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,

--- a/commands/admin_test.go
+++ b/commands/admin_test.go
@@ -1,0 +1,149 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestCanManageChannel(t *testing.T) {
+	tests := []struct {
+		name        string
+		interaction *discordgo.InteractionCreate
+		want        bool
+	}{
+		{
+			name: "Administratorのみ",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionAdministrator,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ManageChannelsのみ",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionManageChannels,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "両方の権限あり",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionAdministrator | discordgo.PermissionManageChannels,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "どちらの権限もなし",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionSendMessages,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "権限ゼロ",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: 0,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "MemberがnilのDM",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: nil,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "ManageChannels含む複数権限",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionManageChannels | discordgo.PermissionSendMessages | discordgo.PermissionViewChannel,
+					},
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := canManageChannel(tt.interaction)
+			if got != tt.want {
+				t.Errorf("canManageChannel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsServerAdmin(t *testing.T) {
+	tests := []struct {
+		name        string
+		interaction *discordgo.InteractionCreate
+		want        bool
+	}{
+		{
+			name: "Administratorあり",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionAdministrator,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "ManageChannelsのみはfalse",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: &discordgo.Member{
+						Permissions: discordgo.PermissionManageChannels,
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "MemberがnilのDM",
+			interaction: &discordgo.InteractionCreate{
+				Interaction: &discordgo.Interaction{
+					Member: nil,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isServerAdmin(tt.interaction)
+			if got != tt.want {
+				t.Errorf("isServerAdmin() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/commands/mute.go
+++ b/commands/mute.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"github.com/bwmarrin/discordgo"
+	"github.com/u16-io/FindSenryu4Discord/pkg/logger"
+	"github.com/u16-io/FindSenryu4Discord/pkg/metrics"
+	"github.com/u16-io/FindSenryu4Discord/service"
+)
+
+// HandleMuteCommand handles the /mute slash command.
+func HandleMuteCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	metrics.RecordCommandExecuted("mute")
+
+	if i.GuildID == "" {
+		respondError(s, i, "このコマンドはサーバー内でのみ使用できます")
+		return
+	}
+
+	if !canManageChannel(i) {
+		respondError(s, i, "このコマンドはサーバー管理者またはチャンネル管理権限を持つユーザーのみ使用できます")
+		return
+	}
+
+	if err := service.ToMute(i.ChannelID, i.GuildID); err != nil {
+		logger.Error("Failed to mute channel", "error", err, "channel_id", i.ChannelID)
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "ミュートに失敗しました",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+	} else {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "このチャンネルでの川柳検出をミュートしました",
+			},
+		})
+	}
+}
+
+// HandleUnmuteCommand handles the /unmute slash command.
+func HandleUnmuteCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
+	metrics.RecordCommandExecuted("unmute")
+
+	if i.GuildID == "" {
+		respondError(s, i, "このコマンドはサーバー内でのみ使用できます")
+		return
+	}
+
+	if !canManageChannel(i) {
+		respondError(s, i, "このコマンドはサーバー管理者またはチャンネル管理権限を持つユーザーのみ使用できます")
+		return
+	}
+
+	if err := service.ToUnMute(i.ChannelID); err != nil {
+		logger.Error("Failed to unmute channel", "error", err, "channel_id", i.ChannelID)
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "ミュート解除に失敗しました",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		})
+	} else {
+		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "このチャンネルでの川柳検出のミュートを解除しました",
+			},
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -41,14 +41,19 @@ var (
 	// adminPermission is used for DefaultMemberPermissions on admin-only commands.
 	adminPermission int64 = discordgo.PermissionAdministrator
 
+	// manageChannelPermission is used for DefaultMemberPermissions on channel management commands.
+	manageChannelPermission int64 = discordgo.PermissionManageChannels
+
 	userCommands = []*discordgo.ApplicationCommand{
 		{
-			Name:        "mute",
-			Description: "このチャンネルでの川柳検出をミュートします",
+			Name:                     "mute",
+			Description:              "このチャンネルでの川柳検出をミュートします",
+			DefaultMemberPermissions: &manageChannelPermission,
 		},
 		{
-			Name:        "unmute",
-			Description: "このチャンネルでの川柳検出のミュートを解除します",
+			Name:                     "unmute",
+			Description:              "このチャンネルでの川柳検出のミュートを解除します",
+			DefaultMemberPermissions: &manageChannelPermission,
 		},
 		{
 			Name:        "rank",
@@ -99,8 +104,8 @@ var (
 	}
 
 	commandHandlers = map[string]func(s *discordgo.Session, i *discordgo.InteractionCreate){
-		"mute":    handleMuteCommand,
-		"unmute":  handleUnmuteCommand,
+		"mute":    commands.HandleMuteCommand,
+		"unmute":  commands.HandleUnmuteCommand,
 		"rank":    handleRankCommand,
 		"channel": commands.HandleChannelCommand,
 		"delete":  commands.HandleDeleteCommand,
@@ -572,50 +577,6 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 }
 
 var medals = []string{"🥇", "🥈", "🥉", "🎖️", "🎖️"}
-
-func handleMuteCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	metrics.RecordCommandExecuted("mute")
-
-	if err := service.ToMute(i.ChannelID, i.GuildID); err != nil {
-		logger.Error("Failed to mute channel", "error", err, "channel_id", i.ChannelID)
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: "ミュートに失敗しました ❌",
-				Flags:   discordgo.MessageFlagsEphemeral,
-			},
-		})
-	} else {
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: "このチャンネルでの川柳検出をミュートしました ✅",
-			},
-		})
-	}
-}
-
-func handleUnmuteCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
-	metrics.RecordCommandExecuted("unmute")
-
-	if err := service.ToUnMute(i.ChannelID); err != nil {
-		logger.Error("Failed to unmute channel", "error", err, "channel_id", i.ChannelID)
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: "ミュート解除に失敗しました ❌",
-				Flags:   discordgo.MessageFlagsEphemeral,
-			},
-		})
-	} else {
-		s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Content: "このチャンネルでの川柳検出のミュートを解除しました ✅",
-			},
-		})
-	}
-}
 
 func handleRankCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 	metrics.RecordCommandExecuted("rank")


### PR DESCRIPTION
## Summary
- `/mute` `/unmute` をサーバー管理者 or チャンネル管理権限保持者のみに制限
- 2層防御: `DefaultMemberPermissions`（UI層）+ `canManageChannel`（実行時層）
- ハンドラを `commands/mute.go` に移動し、DM防止チェックを追加

Closes #90

## Test plan
- [x] `canManageChannel` テスト（7ケース: Administrator/ManageChannels/両方/なし/DM等）
- [x] `isServerAdmin` テスト（3ケース）
- [x] 既存テストのリグレッション確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)