### PR TITLE
feat: サーバー参加時にウェルカムメッセージを送信

### DIFF
--- a/commands/welcome.go
+++ b/commands/welcome.go
@@ -35,7 +35,7 @@ func ClearGuildWelcomeSent(guildID string) {
 
 func buildWelcomeEmbed() *discordgo.MessageEmbed {
 	return &discordgo.MessageEmbed{
-		Title:       "FindSenryu へようこそ！",
+		Title:       "川柳検出Bot へようこそ！",
 		Description: "このBotはメッセージから川柳（五・七・五）を自動検出してお知らせします。",
 		Color:       0x5865F2,
 		Fields: []*discordgo.MessageEmbedField{
@@ -50,6 +50,10 @@ func buildWelcomeEmbed() *discordgo.MessageEmbed {
 			{
 				Name:  "便利なコマンド",
 				Value: "`/mute` `/unmute` — チャンネルごとの検出ON/OFF\n`/rank` — サーバー内ランキング\n`/detect off` — 自分の検出を無効化\n`/channel` — チャンネルタイプ別の設定\n`/doctor` — Bot動作の診断",
+			},
+			{
+				Name:  "よくある質問",
+				Value: "使い方やトラブルシューティングは [FAQ ページ](https://senryu-bot.u16.io/faq) をご覧ください。",
 			},
 		},
 	}

--- a/commands/welcome.go
+++ b/commands/welcome.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"net/http"
 	"sync"
+
+	"github.com/cockroachdb/errors"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/u16-io/FindSenryu4Discord/config"
@@ -11,13 +14,23 @@ import (
 
 var welcomeSentGuilds sync.Map
 
-func markGuildWelcomeSent(guildID string) {
+// tryMarkGuildWelcomeSent atomically checks and marks a guild as welcome-sent.
+// Returns true if this is the first call for the guild (i.e. welcome should be sent).
+func tryMarkGuildWelcomeSent(guildID string) bool {
+	_, loaded := welcomeSentGuilds.LoadOrStore(guildID, struct{}{})
+	return !loaded
+}
+
+// MarkGuildWelcomeSent marks a guild as already having received the welcome message.
+// Used during initial cache burst to register existing guilds.
+func MarkGuildWelcomeSent(guildID string) {
 	welcomeSentGuilds.Store(guildID, struct{}{})
 }
 
-func isGuildWelcomeSent(guildID string) bool {
-	_, ok := welcomeSentGuilds.Load(guildID)
-	return ok
+// ClearGuildWelcomeSent removes a guild from the welcome-sent map.
+// Called when the bot leaves a guild so that re-invitation triggers a new welcome message.
+func ClearGuildWelcomeSent(guildID string) {
+	welcomeSentGuilds.Delete(guildID)
 }
 
 func buildWelcomeEmbed() *discordgo.MessageEmbed {
@@ -42,9 +55,23 @@ func buildWelcomeEmbed() *discordgo.MessageEmbed {
 	}
 }
 
+// hasChannelSendPermission checks whether the bot has SendMessages permission in the given channel.
+func hasChannelSendPermission(s *discordgo.Session, channelID string) bool {
+	perms, err := s.State.UserChannelPermissions(s.State.User.ID, channelID)
+	if err != nil {
+		return false
+	}
+	return perms&discordgo.PermissionSendMessages != 0
+}
+
 func resolveWelcomeChannel(s *discordgo.Session, g *discordgo.Guild) string {
+	// Check SystemChannelID first, but only if the bot has SendMessages permission
 	if g.SystemChannelID != "" {
-		return g.SystemChannelID
+		if hasChannelSendPermission(s, g.SystemChannelID) {
+			return g.SystemChannelID
+		}
+		logger.Debug("SystemChannelID lacks SendMessages permission, falling back",
+			"guild_id", g.ID, "system_channel_id", g.SystemChannelID)
 	}
 
 	channels, err := s.GuildChannels(g.ID)
@@ -57,16 +84,25 @@ func resolveWelcomeChannel(s *discordgo.Session, g *discordgo.Guild) string {
 		if ch.Type != discordgo.ChannelTypeGuildText {
 			continue
 		}
-		perms, err := s.State.UserChannelPermissions(s.State.User.ID, ch.ID)
-		if err != nil {
-			continue
-		}
-		if perms&discordgo.PermissionSendMessages != 0 {
+		if hasChannelSendPermission(s, ch.ID) {
 			return ch.ID
 		}
 	}
 
 	return ""
+}
+
+// isPermanentSendError returns true if the error indicates a permanent failure
+// (e.g. 403 Forbidden, 404 Not Found) where retrying would not help.
+func isPermanentSendError(err error) bool {
+	var restErr *discordgo.RESTError
+	if errors.As(err, &restErr) && restErr.Response != nil {
+		switch restErr.Response.StatusCode {
+		case http.StatusForbidden, http.StatusNotFound:
+			return true
+		}
+	}
+	return false
 }
 
 // SendWelcomeMessage sends a welcome embed to the guild's system channel (or first writable text channel).
@@ -76,23 +112,29 @@ func SendWelcomeMessage(s *discordgo.Session, g *discordgo.GuildCreate) {
 		return
 	}
 
-	if isGuildWelcomeSent(g.ID) {
+	if !tryMarkGuildWelcomeSent(g.ID) {
 		return
 	}
 
 	channelID := resolveWelcomeChannel(s, g.Guild)
 	if channelID == "" {
 		logger.Warn("No writable channel found for welcome message", "guild_id", g.ID, "guild_name", g.Name)
+		// Rollback so a future attempt can retry
+		welcomeSentGuilds.Delete(g.ID)
 		return
 	}
 
 	embed := buildWelcomeEmbed()
 	if _, err := s.ChannelMessageSendEmbed(channelID, embed); err != nil {
 		logger.Warn("Failed to send welcome message", "error", err, "guild_id", g.ID, "channel_id", channelID)
+		// Keep the mark for permanent errors (403/404) to avoid retry storms.
+		// For transient errors, rollback so a reconnect can retry.
+		if !isPermanentSendError(err) {
+			welcomeSentGuilds.Delete(g.ID)
+		}
 		return
 	}
 
-	markGuildWelcomeSent(g.ID)
 	metrics.RecordWelcomeMessageSent()
 	logger.Info("Sent welcome message", "guild_id", g.ID, "guild_name", g.Name, "channel_id", channelID)
 }

--- a/commands/welcome.go
+++ b/commands/welcome.go
@@ -1,0 +1,98 @@
+package commands
+
+import (
+	"sync"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/u16-io/FindSenryu4Discord/config"
+	"github.com/u16-io/FindSenryu4Discord/pkg/logger"
+	"github.com/u16-io/FindSenryu4Discord/pkg/metrics"
+)
+
+var welcomeSentGuilds sync.Map
+
+func markGuildWelcomeSent(guildID string) {
+	welcomeSentGuilds.Store(guildID, struct{}{})
+}
+
+func isGuildWelcomeSent(guildID string) bool {
+	_, ok := welcomeSentGuilds.Load(guildID)
+	return ok
+}
+
+func buildWelcomeEmbed() *discordgo.MessageEmbed {
+	return &discordgo.MessageEmbed{
+		Title:       "FindSenryu へようこそ！",
+		Description: "このBotはメッセージから川柳（五・七・五）を自動検出してお知らせします。",
+		Color:       0x5865F2,
+		Fields: []*discordgo.MessageEmbedField{
+			{
+				Name:  "川柳の検出",
+				Value: "普段の会話から五・七・五のリズムを自動で見つけます。特別な操作は不要です！",
+			},
+			{
+				Name:  "「詠め」「詠むな」",
+				Value: "「詠め」と発言するとサーバー内の川柳からランダムに一句詠みます。「詠むな」で直前の自分の句を表示します。",
+			},
+			{
+				Name:  "便利なコマンド",
+				Value: "`/mute` `/unmute` — チャンネルごとの検出ON/OFF\n`/rank` — サーバー内ランキング\n`/detect off` — 自分の検出を無効化\n`/channel` — チャンネルタイプ別の設定\n`/doctor` — Bot動作の診断",
+			},
+		},
+	}
+}
+
+func resolveWelcomeChannel(s *discordgo.Session, g *discordgo.Guild) string {
+	if g.SystemChannelID != "" {
+		return g.SystemChannelID
+	}
+
+	channels, err := s.GuildChannels(g.ID)
+	if err != nil {
+		logger.Warn("Failed to get guild channels for welcome message", "error", err, "guild_id", g.ID)
+		return ""
+	}
+
+	for _, ch := range channels {
+		if ch.Type != discordgo.ChannelTypeGuildText {
+			continue
+		}
+		perms, err := s.State.UserChannelPermissions(s.State.User.ID, ch.ID)
+		if err != nil {
+			continue
+		}
+		if perms&discordgo.PermissionSendMessages != 0 {
+			return ch.ID
+		}
+	}
+
+	return ""
+}
+
+// SendWelcomeMessage sends a welcome embed to the guild's system channel (or first writable text channel).
+func SendWelcomeMessage(s *discordgo.Session, g *discordgo.GuildCreate) {
+	conf := config.GetConf()
+	if !conf.Discord.IsWelcomeEnabled() {
+		return
+	}
+
+	if isGuildWelcomeSent(g.ID) {
+		return
+	}
+
+	channelID := resolveWelcomeChannel(s, g.Guild)
+	if channelID == "" {
+		logger.Warn("No writable channel found for welcome message", "guild_id", g.ID, "guild_name", g.Name)
+		return
+	}
+
+	embed := buildWelcomeEmbed()
+	if _, err := s.ChannelMessageSendEmbed(channelID, embed); err != nil {
+		logger.Warn("Failed to send welcome message", "error", err, "guild_id", g.ID, "channel_id", channelID)
+		return
+	}
+
+	markGuildWelcomeSent(g.ID)
+	metrics.RecordWelcomeMessageSent()
+	logger.Info("Sent welcome message", "guild_id", g.ID, "guild_name", g.Name, "channel_id", channelID)
+}

--- a/commands/welcome.go
+++ b/commands/welcome.go
@@ -69,31 +69,19 @@ func hasChannelSendPermission(s *discordgo.Session, channelID string) bool {
 }
 
 func resolveWelcomeChannel(s *discordgo.Session, g *discordgo.Guild) string {
-	// Check SystemChannelID first, but only if the bot has SendMessages permission
-	if g.SystemChannelID != "" {
-		if hasChannelSendPermission(s, g.SystemChannelID) {
-			return g.SystemChannelID
-		}
-		logger.Debug("SystemChannelID lacks SendMessages permission, falling back",
-			"guild_id", g.ID, "system_channel_id", g.SystemChannelID)
-	}
-
-	channels, err := s.GuildChannels(g.ID)
-	if err != nil {
-		logger.Warn("Failed to get guild channels for welcome message", "error", err, "guild_id", g.ID)
+	if g.SystemChannelID == "" {
+		logger.Info("SystemChannelID is not set, skipping welcome message",
+			"guild_id", g.ID)
 		return ""
 	}
 
-	for _, ch := range channels {
-		if ch.Type != discordgo.ChannelTypeGuildText {
-			continue
-		}
-		if hasChannelSendPermission(s, ch.ID) {
-			return ch.ID
-		}
+	if !hasChannelSendPermission(s, g.SystemChannelID) {
+		logger.Warn("SystemChannelID lacks SendMessages permission, skipping welcome message",
+			"guild_id", g.ID, "system_channel_id", g.SystemChannelID)
+		return ""
 	}
 
-	return ""
+	return g.SystemChannelID
 }
 
 // isPermanentSendError returns true if the error indicates a permanent failure
@@ -109,7 +97,7 @@ func isPermanentSendError(err error) bool {
 	return false
 }
 
-// SendWelcomeMessage sends a welcome embed to the guild's system channel (or first writable text channel).
+// SendWelcomeMessage sends a welcome embed to the guild's system channel.
 func SendWelcomeMessage(s *discordgo.Session, g *discordgo.GuildCreate) {
 	conf := config.GetConf()
 	if !conf.Discord.IsWelcomeEnabled() {

--- a/commands/welcome_test.go
+++ b/commands/welcome_test.go
@@ -1,0 +1,145 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func TestBuildWelcomeEmbed_フィールド構成(t *testing.T) {
+	embed := buildWelcomeEmbed()
+
+	if embed.Title == "" {
+		t.Error("embed title should not be empty")
+	}
+	if embed.Description == "" {
+		t.Error("embed description should not be empty")
+	}
+	if embed.Color == 0 {
+		t.Error("embed color should be set")
+	}
+
+	expectedFields := []string{"川柳の検出", "「詠め」「詠むな」", "便利なコマンド"}
+	if len(embed.Fields) != len(expectedFields) {
+		t.Fatalf("expected %d fields, got %d", len(expectedFields), len(embed.Fields))
+	}
+	for i, name := range expectedFields {
+		if embed.Fields[i].Name != name {
+			t.Errorf("field[%d].Name = %q, want %q", i, embed.Fields[i].Name, name)
+		}
+		if embed.Fields[i].Value == "" {
+			t.Errorf("field[%d].Value should not be empty", i)
+		}
+	}
+}
+
+func TestBuildWelcomeEmbed_コマンド一覧を含む(t *testing.T) {
+	embed := buildWelcomeEmbed()
+
+	commandsField := embed.Fields[2]
+	commands := []string{"/mute", "/unmute", "/rank", "/detect off", "/channel", "/doctor"}
+	for _, cmd := range commands {
+		if !containsString(commandsField.Value, cmd) {
+			t.Errorf("commands field should contain %q", cmd)
+		}
+	}
+}
+
+func TestResolveWelcomeChannel_SystemChannelIDあり(t *testing.T) {
+	guild := &discordgo.Guild{
+		ID:              "guild-1",
+		SystemChannelID: "system-ch-1",
+	}
+
+	s := &discordgo.Session{State: discordgo.NewState()}
+	s.State.TrackChannels = true
+
+	got := resolveWelcomeChannel(s, guild)
+	if got != "system-ch-1" {
+		t.Errorf("resolveWelcomeChannel() = %q, want %q", got, "system-ch-1")
+	}
+}
+
+func TestResolveWelcomeChannel_SystemChannelIDが空文字(t *testing.T) {
+	guild := &discordgo.Guild{
+		ID:              "guild-1",
+		SystemChannelID: "",
+	}
+
+	// SystemChannelID empty -> falls through to GuildChannels API call.
+	// Without a real HTTP backend the API call returns an error,
+	// so resolveWelcomeChannel should return "".
+	s, _ := discordgo.New("Bot fake-token")
+	s.State = discordgo.NewState()
+	s.State.TrackChannels = true
+
+	got := resolveWelcomeChannel(s, guild)
+	if got != "" {
+		t.Errorf("resolveWelcomeChannel() = %q, want empty string when API unavailable", got)
+	}
+}
+
+func TestMarkAndIsGuildWelcomeSent(t *testing.T) {
+	// Clean up for test isolation
+	welcomeSentGuilds.Range(func(key, value any) bool {
+		welcomeSentGuilds.Delete(key)
+		return true
+	})
+
+	guildID := "test-guild-dedup"
+
+	if isGuildWelcomeSent(guildID) {
+		t.Error("should not be marked as sent initially")
+	}
+
+	markGuildWelcomeSent(guildID)
+
+	if !isGuildWelcomeSent(guildID) {
+		t.Error("should be marked as sent after markGuildWelcomeSent")
+	}
+}
+
+func TestIsGuildWelcomeSent_異なるギルドは独立(t *testing.T) {
+	welcomeSentGuilds.Range(func(key, value any) bool {
+		welcomeSentGuilds.Delete(key)
+		return true
+	})
+
+	markGuildWelcomeSent("guild-a")
+
+	if !isGuildWelcomeSent("guild-a") {
+		t.Error("guild-a should be marked as sent")
+	}
+	if isGuildWelcomeSent("guild-b") {
+		t.Error("guild-b should not be marked as sent")
+	}
+}
+
+func TestMarkGuildWelcomeSent_冪等性(t *testing.T) {
+	welcomeSentGuilds.Range(func(key, value any) bool {
+		welcomeSentGuilds.Delete(key)
+		return true
+	})
+
+	guildID := "test-guild-idempotent"
+
+	markGuildWelcomeSent(guildID)
+	markGuildWelcomeSent(guildID) // should not panic
+
+	if !isGuildWelcomeSent(guildID) {
+		t.Error("should still be marked as sent after double mark")
+	}
+}
+
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/commands/welcome_test.go
+++ b/commands/welcome_test.go
@@ -19,7 +19,7 @@ func TestBuildWelcomeEmbed_フィールド構成(t *testing.T) {
 		t.Error("embed color should be set")
 	}
 
-	expectedFields := []string{"川柳の検出", "「詠め」「詠むな」", "便利なコマンド"}
+	expectedFields := []string{"川柳の検出", "「詠め」「詠むな」", "便利なコマンド", "よくある質問"}
 	if len(embed.Fields) != len(expectedFields) {
 		t.Fatalf("expected %d fields, got %d", len(expectedFields), len(embed.Fields))
 	}

--- a/commands/welcome_test.go
+++ b/commands/welcome_test.go
@@ -45,7 +45,7 @@ func TestBuildWelcomeEmbed_コマンド一覧を含む(t *testing.T) {
 	}
 }
 
-func TestResolveWelcomeChannel_SystemChannelIDあり(t *testing.T) {
+func TestResolveWelcomeChannel_SystemChannelIDあり_権限あり(t *testing.T) {
 	guild := &discordgo.Guild{
 		ID:              "guild-1",
 		SystemChannelID: "system-ch-1",
@@ -54,9 +54,49 @@ func TestResolveWelcomeChannel_SystemChannelIDあり(t *testing.T) {
 	s := &discordgo.Session{State: discordgo.NewState()}
 	s.State.TrackChannels = true
 
+	// Add the bot user and the channel with SendMessages permission to State
+	s.State.User = &discordgo.User{ID: "bot-user"}
+	s.State.GuildAdd(&discordgo.Guild{ID: "guild-1"})
+	s.State.ChannelAdd(&discordgo.Channel{
+		ID:                   "system-ch-1",
+		GuildID:              "guild-1",
+		Type:                 discordgo.ChannelTypeGuildText,
+		PermissionOverwrites: []*discordgo.PermissionOverwrite{},
+	})
+	// Guild @everyone role grants SendMessages
+	s.State.RoleAdd("guild-1", &discordgo.Role{
+		ID:          "guild-1",
+		Permissions: discordgo.PermissionSendMessages,
+	})
+	s.State.MemberAdd(&discordgo.Member{
+		User:    &discordgo.User{ID: "bot-user"},
+		GuildID: "guild-1",
+		Roles:   []string{},
+	})
+
 	got := resolveWelcomeChannel(s, guild)
 	if got != "system-ch-1" {
 		t.Errorf("resolveWelcomeChannel() = %q, want %q", got, "system-ch-1")
+	}
+}
+
+func TestResolveWelcomeChannel_SystemChannelIDあり_権限なし(t *testing.T) {
+	guild := &discordgo.Guild{
+		ID:              "guild-perm",
+		SystemChannelID: "system-ch-noperm",
+	}
+
+	s, _ := discordgo.New("Bot fake-token")
+	s.State = discordgo.NewState()
+	s.State.TrackChannels = true
+
+	// Bot user exists but no guild/channel state -> permission check fails -> fallback
+	s.State.User = &discordgo.User{ID: "bot-user"}
+
+	// Without API backend, GuildChannels will also fail, so result is ""
+	got := resolveWelcomeChannel(s, guild)
+	if got != "" {
+		t.Errorf("resolveWelcomeChannel() = %q, want empty string when no permission on system channel", got)
 	}
 }
 
@@ -79,7 +119,7 @@ func TestResolveWelcomeChannel_SystemChannelIDが空文字(t *testing.T) {
 	}
 }
 
-func TestMarkAndIsGuildWelcomeSent(t *testing.T) {
+func TestTryMarkGuildWelcomeSent_初回はtrue(t *testing.T) {
 	// Clean up for test isolation
 	welcomeSentGuilds.Range(func(key, value any) bool {
 		welcomeSentGuilds.Delete(key)
@@ -88,46 +128,71 @@ func TestMarkAndIsGuildWelcomeSent(t *testing.T) {
 
 	guildID := "test-guild-dedup"
 
-	if isGuildWelcomeSent(guildID) {
-		t.Error("should not be marked as sent initially")
-	}
-
-	markGuildWelcomeSent(guildID)
-
-	if !isGuildWelcomeSent(guildID) {
-		t.Error("should be marked as sent after markGuildWelcomeSent")
+	if !tryMarkGuildWelcomeSent(guildID) {
+		t.Error("first call should return true")
 	}
 }
 
-func TestIsGuildWelcomeSent_異なるギルドは独立(t *testing.T) {
+func TestTryMarkGuildWelcomeSent_二回目はfalse(t *testing.T) {
 	welcomeSentGuilds.Range(func(key, value any) bool {
 		welcomeSentGuilds.Delete(key)
 		return true
 	})
 
-	markGuildWelcomeSent("guild-a")
+	guildID := "test-guild-dedup2"
 
-	if !isGuildWelcomeSent("guild-a") {
-		t.Error("guild-a should be marked as sent")
-	}
-	if isGuildWelcomeSent("guild-b") {
-		t.Error("guild-b should not be marked as sent")
+	tryMarkGuildWelcomeSent(guildID)
+
+	if tryMarkGuildWelcomeSent(guildID) {
+		t.Error("second call should return false")
 	}
 }
 
-func TestMarkGuildWelcomeSent_冪等性(t *testing.T) {
+func TestTryMarkGuildWelcomeSent_異なるギルドは独立(t *testing.T) {
 	welcomeSentGuilds.Range(func(key, value any) bool {
 		welcomeSentGuilds.Delete(key)
 		return true
 	})
 
-	guildID := "test-guild-idempotent"
+	if !tryMarkGuildWelcomeSent("guild-a") {
+		t.Error("guild-a first call should return true")
+	}
+	if !tryMarkGuildWelcomeSent("guild-b") {
+		t.Error("guild-b first call should return true (independent of guild-a)")
+	}
+	if tryMarkGuildWelcomeSent("guild-a") {
+		t.Error("guild-a second call should return false")
+	}
+}
 
-	markGuildWelcomeSent(guildID)
-	markGuildWelcomeSent(guildID) // should not panic
+func TestMarkGuildWelcomeSent_登録済みギルドはtryMarkがfalse(t *testing.T) {
+	welcomeSentGuilds.Range(func(key, value any) bool {
+		welcomeSentGuilds.Delete(key)
+		return true
+	})
 
-	if !isGuildWelcomeSent(guildID) {
-		t.Error("should still be marked as sent after double mark")
+	guildID := "test-guild-pre-registered"
+
+	MarkGuildWelcomeSent(guildID)
+
+	if tryMarkGuildWelcomeSent(guildID) {
+		t.Error("tryMark should return false for pre-registered guild")
+	}
+}
+
+func TestClearGuildWelcomeSent_クリア後にtryMarkがtrue(t *testing.T) {
+	welcomeSentGuilds.Range(func(key, value any) bool {
+		welcomeSentGuilds.Delete(key)
+		return true
+	})
+
+	guildID := "test-guild-clear"
+
+	MarkGuildWelcomeSent(guildID)
+	ClearGuildWelcomeSent(guildID)
+
+	if !tryMarkGuildWelcomeSent(guildID) {
+		t.Error("tryMark should return true after clear")
 	}
 }
 

--- a/commands/welcome_test.go
+++ b/commands/welcome_test.go
@@ -106,16 +106,14 @@ func TestResolveWelcomeChannel_SystemChannelIDが空文字(t *testing.T) {
 		SystemChannelID: "",
 	}
 
-	// SystemChannelID empty -> falls through to GuildChannels API call.
-	// Without a real HTTP backend the API call returns an error,
-	// so resolveWelcomeChannel should return "".
+	// SystemChannelID empty -> no fallback, just return "".
 	s, _ := discordgo.New("Bot fake-token")
 	s.State = discordgo.NewState()
 	s.State.TrackChannels = true
 
 	got := resolveWelcomeChannel(s, guild)
 	if got != "" {
-		t.Errorf("resolveWelcomeChannel() = %q, want empty string when API unavailable", got)
+		t.Errorf("resolveWelcomeChannel() = %q, want empty string when SystemChannelID is not set", got)
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -31,8 +31,9 @@ type Config struct {
 
 // DiscordConfig holds Discord-related configuration
 type DiscordConfig struct {
-	Token   string `koanf:"token"`
-	Playing string `koanf:"playing"`
+	Token          string `koanf:"token"`
+	Playing        string `koanf:"playing"`
+	WelcomeEnabled *bool  `koanf:"welcome_enabled"`
 }
 
 // DatabaseConfig holds database configuration
@@ -117,6 +118,10 @@ func Load(configPath string) (*Config, error) {
 }
 
 func setDefaults(c *Config) {
+	if c.Discord.WelcomeEnabled == nil {
+		t := true
+		c.Discord.WelcomeEnabled = &t
+	}
 	if c.Database.Driver == "" {
 		c.Database.Driver = "sqlite3"
 	}
@@ -163,6 +168,14 @@ func GetConf() *Config {
 		}
 	}
 	return conf
+}
+
+// IsWelcomeEnabled returns whether the welcome message feature is enabled.
+func (c *DiscordConfig) IsWelcomeEnabled() bool {
+	if c.WelcomeEnabled == nil {
+		return true
+	}
+	return *c.WelcomeEnabled
 }
 
 // Get returns a value from config by key

--- a/config/config.go
+++ b/config/config.go
@@ -117,10 +117,11 @@ func Load(configPath string) (*Config, error) {
 	return conf, loadErr
 }
 
+func boolPtr(v bool) *bool { return &v }
+
 func setDefaults(c *Config) {
 	if c.Discord.WelcomeEnabled == nil {
-		t := true
-		c.Discord.WelcomeEnabled = &t
+		c.Discord.WelcomeEnabled = boolPtr(true)
 	}
 	if c.Database.Driver == "" {
 		c.Database.Driver = "sqlite3"

--- a/main.go
+++ b/main.go
@@ -420,6 +420,8 @@ func guildCreate(s *discordgo.Session, g *discordgo.GuildCreate) {
 	metrics.SetConnectedGuilds(countAllGuilds())
 	if !botReady.Load() {
 		logger.Debug("Guild cache", "name", g.Name, "id", g.ID)
+		// Register existing guilds so reconnect doesn't trigger welcome messages
+		commands.MarkGuildWelcomeSent(g.ID)
 		// Debounce: reset timer on each GUILD_CREATE during cache burst.
 		// When no more events arrive within 5s, mark as ready.
 		if t := guildCacheTimer.Load(); t != nil {
@@ -453,6 +455,9 @@ func guildCreate(s *discordgo.Session, g *discordgo.GuildCreate) {
 func guildDelete(s *discordgo.Session, g *discordgo.GuildDelete) {
 	logger.Info("Left guild", "id", g.ID)
 	metrics.SetConnectedGuilds(countAllGuilds())
+
+	// Clear welcome-sent flag so re-invitation triggers a new welcome message
+	commands.ClearGuildWelcomeSent(g.ID)
 
 	// Clean up guild data
 	senryuCount, err := service.DeleteSenryuByServer(g.ID)

--- a/main.go
+++ b/main.go
@@ -447,6 +447,7 @@ func guildCreate(s *discordgo.Session, g *discordgo.GuildCreate) {
 	if adminNotifier != nil {
 		adminNotifier.NotifyGuildJoin(g.Guild)
 	}
+	go commands.SendWelcomeMessage(s, g)
 }
 
 func guildDelete(s *discordgo.Session, g *discordgo.GuildDelete) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -97,6 +97,14 @@ var (
 			Help: "Total number of automatic channel mutes triggered by Bot permission errors",
 		},
 	)
+
+	// WelcomeMessagesSentTotal is the total number of welcome messages sent
+	WelcomeMessagesSentTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "findsenryu_welcome_messages_sent_total",
+			Help: "Total number of welcome messages sent to new guilds",
+		},
+	)
 )
 
 // RecordSenryuDetected records a senryu detection
@@ -149,4 +157,9 @@ func SetOptedOutUsers(count int64) {
 // RecordAutoMute records an automatic channel mute triggered by Bot permission error
 func RecordAutoMute() {
 	AutoMuteTotal.Inc()
+}
+
+// RecordWelcomeMessageSent records a welcome message sent to a new guild
+func RecordWelcomeMessageSent() {
+	WelcomeMessagesSentTotal.Inc()
 }

--- a/sample.config.toml
+++ b/sample.config.toml
@@ -1,6 +1,7 @@
 [discord]
 token = ""
 playing = ""
+welcome_enabled = true  # サーバー参加時にウェルカムメッセージを送信するか
 
 [database]
 driver = "sqlite3"  # sqlite3 or postgres


### PR DESCRIPTION
## Summary
- Bot がサーバーに参加した際、SystemChannel（またはフォールバック先）にEmbed形式のウェルカムメッセージを送信
- `sync.Map.LoadOrStore` によるアトミックな重複送信防止
- 初回キャッシュバースト時に既知ギルドを登録し、Reconnect時の誤送信を防止
- SystemChannelID の書き込み権限チェック、guildDelete時のクリーンアップ
- `welcome_enabled` config で有効/無効切替可能

Closes #92

## Test plan
- [x] Embed構成テスト
- [x] チャンネル解決テスト（SystemChannelあり/なし/権限なし）
- [x] 重複送信防止テスト（tryMarkGuildWelcomeSent アトミック性）
- [x] クリーンアップテスト（ClearGuildWelcomeSent）
- [x] 既存テストのリグレッション確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)