### PR TITLE
feat: /rank コマンドにサーバー統計情報を表示

### DIFF
--- a/main.go
+++ b/main.go
@@ -652,6 +652,11 @@ func handleRankCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		return
 	}
 
+	stats, statsErr := service.GetServerStats(i.GuildID)
+	if statsErr != nil {
+		logger.Warn("Failed to get server stats", "error", statsErr, "guild_id", i.GuildID)
+	}
+
 	guild, err := s.State.Guild(i.GuildID)
 	if err != nil {
 		guild, err = s.Guild(i.GuildID)
@@ -665,6 +670,13 @@ func handleRankCommand(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		Title:     "サーバー内ランキング",
 		Timestamp: time.Now().Format(time.RFC3339),
 		Fields:    []*discordgo.MessageEmbedField{},
+	}
+	if statsErr == nil {
+		if stats.TotalSenryus == 0 {
+			embed.Description = "まだ誰も詠んでいません"
+		} else {
+			embed.Description = fmt.Sprintf("累計 **%d** 句 / **%d** 人の詠み手", stats.TotalSenryus, stats.UniqueAuthors)
+		}
 	}
 	if guild != nil {
 		embed.Footer = &discordgo.MessageEmbedFooter{

--- a/service/senryu_test.go
+++ b/service/senryu_test.go
@@ -642,6 +642,75 @@ func TestCountSenryusByAuthor_別ユーザーは含まない(t *testing.T) {
 	}
 }
 
+func TestGetServerStats_正常系(t *testing.T) {
+	setupSenryuTestDB(t)
+	crypto.Init("")
+	seedSenryus(t, "guild1", "user1", 3)
+	seedSenryus(t, "guild1", "user2", 2)
+
+	stats, err := GetServerStats("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalSenryus != 5 {
+		t.Errorf("TotalSenryus = %d, want 5", stats.TotalSenryus)
+	}
+	if stats.UniqueAuthors != 2 {
+		t.Errorf("UniqueAuthors = %d, want 2", stats.UniqueAuthors)
+	}
+}
+
+func TestGetServerStats_川柳が0件(t *testing.T) {
+	setupSenryuTestDB(t)
+	crypto.Init("")
+
+	stats, err := GetServerStats("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalSenryus != 0 {
+		t.Errorf("TotalSenryus = %d, want 0", stats.TotalSenryus)
+	}
+	if stats.UniqueAuthors != 0 {
+		t.Errorf("UniqueAuthors = %d, want 0", stats.UniqueAuthors)
+	}
+}
+
+func TestGetServerStats_別サーバーの川柳は含まない(t *testing.T) {
+	setupSenryuTestDB(t)
+	crypto.Init("")
+	seedSenryus(t, "guild1", "user1", 3)
+	seedSenryus(t, "guild2", "user2", 5)
+
+	stats, err := GetServerStats("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalSenryus != 3 {
+		t.Errorf("TotalSenryus = %d, want 3", stats.TotalSenryus)
+	}
+	if stats.UniqueAuthors != 1 {
+		t.Errorf("UniqueAuthors = %d, want 1", stats.UniqueAuthors)
+	}
+}
+
+func TestGetServerStats_同一ユーザーが複数句(t *testing.T) {
+	setupSenryuTestDB(t)
+	crypto.Init("")
+	seedSenryus(t, "guild1", "user1", 7)
+
+	stats, err := GetServerStats("guild1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stats.TotalSenryus != 7 {
+		t.Errorf("TotalSenryus = %d, want 7", stats.TotalSenryus)
+	}
+	if stats.UniqueAuthors != 1 {
+		t.Errorf("UniqueAuthors = %d, want 1", stats.UniqueAuthors)
+	}
+}
+
 func TestGetLastSenryu_最後の川柳を返す(t *testing.T) {
 	setupSenryuTestDB(t)
 	if err := crypto.Init(""); err != nil {


### PR DESCRIPTION
## Summary
- `/rank` コマンドの Embed に累計川柳数とユニーク詠み手数を表示
- `GetServerStats` の単体テスト4件を追加

Closes #83

## Detail
既存の未使用関数 `service.GetServerStats()` を `/rank` ハンドラから呼び出し、Embed の Description に `累計 XX 句 / YY 人の詠み手` を表示する。統計取得失敗時はランキング表示のみ続行。

## Test plan
- [x] `GetServerStats` 正常系（複数ユーザー・複数句）
- [x] 川柳0件のサーバー
- [x] 別サーバーの川柳が混入しないこと
- [x] 同一ユーザーの複数句

🤖 Generated with [Claude Code](https://claude.com/claude-code)