### PR TITLE
fix: 暗号化マイグレーションが実行されない問題を修正

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/u16-io/FindSenryu4Discord/config"
 	"github.com/u16-io/FindSenryu4Discord/db"
+	"github.com/u16-io/FindSenryu4Discord/pkg/crypto"
 	"github.com/u16-io/FindSenryu4Discord/pkg/logger"
 )
 
@@ -21,8 +22,15 @@ func main() {
 		Format: conf.Log.Format,
 	})
 
+	if err := crypto.Init(conf.Encryption.Key); err != nil {
+		logger.Error("Failed to initialize encryption", "error", err)
+		os.Exit(1)
+	}
+	conf.Encryption.Key = ""
+
 	logger.Info("Starting database migration",
 		"db_driver", conf.Database.Driver,
+		"encryption_enabled", crypto.IsEnabled(),
 	)
 
 	if err := db.Init(); err != nil {

--- a/db/db.go
+++ b/db/db.go
@@ -150,8 +150,11 @@ func Migrate() error {
 		return errors.New("database contains encrypted data but encryption key is not configured; set encryption.key in config")
 	}
 
-	// Encrypt existing plaintext senryu data if encryption is enabled
-	if crypto.IsEnabled() && !isEncryptionMigrated() {
+	// Encrypt existing plaintext senryu data if encryption is enabled.
+	// Always run (not gated by isEncryptionMigrated) because the function is
+	// idempotent and skips already-encrypted records. This ensures late-arriving
+	// plaintext rows are caught on every startup.
+	if crypto.IsEnabled() {
 		if err := migrateEncryptSenryuData(); err != nil {
 			logger.Error("Failed to encrypt existing senryu data", "error", err)
 			return err

--- a/service/senryu.go
+++ b/service/senryu.go
@@ -39,19 +39,26 @@ func encryptSenryuFields(s *model.Senryu) error {
 }
 
 // decryptSenryuFields decrypts the content fields (Kamigo, Nakasichi, Simogo) in place.
+// Plaintext (unencrypted) fields are left as-is.
 func decryptSenryuFields(s *model.Senryu) error {
 	if !crypto.IsEnabled() {
 		return nil
 	}
 	var err error
-	if s.Kamigo, err = crypto.Decrypt(s.Kamigo); err != nil {
-		return errors.Wrap(ErrDecryptFailed, err.Error())
+	if crypto.IsEncrypted(s.Kamigo) {
+		if s.Kamigo, err = crypto.Decrypt(s.Kamigo); err != nil {
+			return errors.Wrap(ErrDecryptFailed, err.Error())
+		}
 	}
-	if s.Nakasichi, err = crypto.Decrypt(s.Nakasichi); err != nil {
-		return errors.Wrap(ErrDecryptFailed, err.Error())
+	if crypto.IsEncrypted(s.Nakasichi) {
+		if s.Nakasichi, err = crypto.Decrypt(s.Nakasichi); err != nil {
+			return errors.Wrap(ErrDecryptFailed, err.Error())
+		}
 	}
-	if s.Simogo, err = crypto.Decrypt(s.Simogo); err != nil {
-		return errors.Wrap(ErrDecryptFailed, err.Error())
+	if crypto.IsEncrypted(s.Simogo) {
+		if s.Simogo, err = crypto.Decrypt(s.Simogo); err != nil {
+			return errors.Wrap(ErrDecryptFailed, err.Error())
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- `cmd/migrate` で `crypto.Init()` が呼ばれておらず、暗号化マイグレーションが常にスキップされていた問題を修正
- 暗号化マイグレーションを毎起動時に実行するよう変更（冪等のためガード不要）
- `decryptSenryuFields` で平文レコードをクラッシュせず読めるよう `IsEncrypted` チェックを追加

## Background
本番DB（854,391件）のうち暗号化済みはわずか4件（`CreateSenryu` 経由の最新レコードのみ）。
`cmd/migrate/main.go` が `crypto.Init()` を呼んでいなかったため、`crypto.IsEnabled()` が常に `false` → `migrateEncryptSenryuData()` がスキップされていた。

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `cmd/migrate/main.go` | `crypto.Init(conf.Encryption.Key)` を追加 |
| `db/db.go` | `!isEncryptionMigrated()` ガードを削除、毎回実行に変更 |
| `service/senryu.go` | `decryptSenryuFields` で各フィールドの復号前に `IsEncrypted` チェック |

## Test plan
- [x] `go test ./...` 全件 PASS
- [ ] デプロイ後、migrate サービスのログで `Encrypted existing senryu data` が出力されること
- [ ] `metadata` テーブルに `encryption_migrated = true` がセットされること
- [ ] 平文レコードの読み取り（`/rank`, よめよむな等）がエラーにならないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)